### PR TITLE
chore: ajout de .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD004": { "style": "dash" },
+  "MD013": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
   "MD004": { "style": "dash" },
   "MD013": false,
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }


### PR DESCRIPTION
## Description des changements

* Ajout de `.markdownlint.json` à la racine du projet pour adapter les règles markdownlint aux conventions des IGs FHIR ANS

Règles configurées :
- `MD004` style `dash` : autorise la syntaxe `- [ ]` des checklists GitHub dans les PR templates
- `MD013` désactivée : pas de limite de longueur de ligne (lignes longues courantes dans les docs techniques FHIR)
- `MD033` désactivée : autorise le HTML inline (divs colorés métier/technique/transversal utilisés dans toutes les pages)
- `MD041` désactivée : autorise les pages commençant à `###` (convention ANS — `#` et `##` sont générés automatiquement par le publisher)

## Preview

https://ansforge.github.io/IG-modele/fix/markdownlint-config/ig

Fixes #39