### PR TITLE
fix: masque les messages PIN_VERSION du rapport QA

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -4,37 +4,6 @@
 # instructions for ignoreWarnings.txt https://confluence.hl7.org/pages/viewpage.action?pageId=66938614#ImplementationGuideParameters-ManagingWarningsandHints
 # (And include comments like this justifying why)
 
-# We expect that all of the 'structural' resources will only be validated against their respective 'core' resource definitions
-Validate resource against profile http://hl7.org/fhir/StructureDefinition/ImplementationGuide
-Validate resource against profile http://hl7.org/fhir/StructureDefinition/Library
-Validate resource against profile http://hl7.org/fhir/StructureDefinition/ValueSet
-Validate resource against profile http://hl7.org/fhir/StructureDefinition/StructureDefinition
-
-# Have verified that these examples are being checked against the expected profiles/resources.
-INFORMATION: Binary/example: Binary: Validate resource against profile http://hl7.org/fhir/StructureDefinition/Binary
-INFORMATION: Bundle/h1: Bundle: Validate resource against profile http://hl7.org/fhir/StructureDefinition/Bundle
-INFORMATION: Bundle/h1: Bundle.entry[0].resource.ofType(Provenance): Validate resource against profile http://hl7.org/fhir/StructureDefinition/Provenance
-INFORMATION: Patient/example: Patient: Validate resource against profile http://somewhere.org/fhir/uv/myig/StructureDefinition/mypatient
-
-# This is inherited from the base resource
-WARNING: StructureDefinition/myObservation: StructureDefinition.snapshot.element[15].mapping[3].map: value should not start or finish with whitespace
-
-# These examples are fake code systems - they're not expected to be checked
-Code System URI 'http://example.org/some-id-type-system' is unknown so the code cannot be validated
-Code System URI 'http://example.org/some-system' is unknown so the code cannot be validated
-
-# We're expecting these to not match the slice - we're showing how you can use slicing to define the one repetition you want even when many repetitions might be present
-INFORMATION: Patient/example: Patient.name[0]: This element does not match any known slice defined in the profile http://somewhere.org/fhir/uv/myig/StructureDefinition/mypatient
-INFORMATION: Patient/example: Patient.name[1]: This element does not match any known slice defined in the profile http://somewhere.org/fhir/uv/myig/StructureDefinition/mypatient
-
-# If this was a real IG, there should be examples for these profiles too.  But it's not, and I'm lazy...
-WARNING: StructureDefinition.where(url = 'http://somewhere.org/fhir/uv/myig/StructureDefinition/mypractitioner'): The Implementation Guide contains no examples for this profile
-WARNING: StructureDefinition.where(url = 'http://somewhere.org/fhir/uv/myig/StructureDefinition/myObservation'): The Implementation Guide contains no examples for this profile
-
-# The objective is to show a reference to an unknown code system, so these warnings are expected
-WARNING: ValueSet/valueset-no-codesystem: ValueSet.compose[0].include[0]: Unknown System/Version specified, so Concepts and Filters can''t be checked
-WARNING: ValueSet.where(id = 'valueset-no-codesystem'): Error from server: Unable to provide support for code system http://not-a-known-code-system
-
-# We don't want a code for the change reason (and this binding shouldn't be extensible anyhow)
-WARNING: Bundle/h1: Bundle.entry[0].resource.ofType(Provenance).reason[0]: No code provided, and a code should be provided from the value set 'PurposeOfUse' (http://terminology.hl7.org/ValueSet/v3-PurposeOfUse)
-WARNING: Bundle/h1: Bundle.entry[0].resource.ofType(Provenance).reason[0]: No code provided, and a code should be provided from the value set 'PurposeOfUse' (http://terminology.hl7.org/ValueSet/v3-PurposeOfUse)
+# pin-canonicals: pin-all épingle intentionnellement toutes les références canoniques non
+# versionnées ; ce message purement informatif ne signale aucun problème
+PIN_VERSION

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -22,6 +22,7 @@ parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/Code
     shownav: 'true'
     path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
     pin-canonicals: pin-all
+    path-suppressed-warnings: input/ignoreWarnings.txt
     apply-contact: true
     show-inherited-invariants: true
     logging:


### PR DESCRIPTION
## Description des changements

* `sushi-config.yaml` : ajout du paramètre `path-suppressed-warnings: input/ignoreWarnings.txt` pour activer le mécanisme officiel de suppression de messages du IG Publisher (documenté sur https://build.fhir.org/ig/FHIR/fhir-tools-ig/en/CodeSystem-ig-parameters.html).
* `input/ignoreWarnings.txt` : ce fichier existait déjà mais n'était pas encore chargé (le paramètre ci-dessus manquait) et ne contenait que le contenu placeholder du template `FHIR/sample-ig`. Remplacé par une entrée `PIN_VERSION` — l'ID interne stable du message `Pinned the version of X to Y`, généré en très grand nombre par `pin-canonicals: pin-all` (voir constat fait sur https://github.com/ansforge/interop-IG-cda-document-core, où ces messages représentaient 98% du rapport QA). **Aucun changement de comportement de pinning** : seul l'affichage de ces messages dans qa.html/qa.txt est masqué.
* Ce dépôt étant le template dont sont dérivés les nouveaux IG ANS, les IG créés à partir de maintenant bénéficieront directement de ce réglage.

## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour — non applicable, contenu encore au format placeholder (`xxx`), pas de release en cours
- [x] La branche est à jour avec `main`

## Note sur la validation

Ce mécanisme est propre au IG Publisher Java (génération de qa.html), pas à SUSHI. `sushi .` n'a pas pu être exécuté sur cette copie locale du template (dossier `fsh-generated` préexistant appartenant à `root`, sans rapport avec ce changement), mais la config a été relue et suit exactement le même schéma que la correction déjà appliquée et vérifiée sur `interop-IG-cda-document-core`.

## Preview

https://ansforge.github.io/IG-modele/fix/hide-pin-version-qa-messages/ig